### PR TITLE
ci: @testing-library/jest-dom agregada a lista de librerias prohibidas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lintastic",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Eslint Remoto con las reglas unificadas de Asincode",
   "main": "lib/index.js",
   "type": "module",
@@ -70,6 +70,7 @@
     "statements": 0
   },
   "directories": {
+    "lib": "lib",
     "test": "test"
   },
   "bugs": {

--- a/src/rules.js
+++ b/src/rules.js
@@ -80,6 +80,10 @@ export const rulesJS = {
           message: "No se permite importar '@types/axios'. Usa la definición de tipos incluida en axios."
         },
         {
+          name: "@testing-library/jest-dom",
+          message: "Evita usar '@testing-library/jest-dom' ya que depende de Jest. Considera utilizar soluciones nativas de Node.js para pruebas o alternativas modernas para Front como Vitest."
+        },
+        {
           name: "date-fns",
           message: "El uso de 'date-fns' no está recomendado. Consulta https://youmightnotneed.com/date-fns para alternativas más ligeras o nativas."
         },


### PR DESCRIPTION
## Descripción

Este pull request incluye la desautorización del uso de la librería `@testing-library/jest-dom`. 

## Tipo de cambio

• [ ] Nueva funcionalidad  
• [ ] Corrección de errores  
• [ ] Mejoras en el rendimiento  
• [x] Refactorización  
• [ ] Otros (especificar):  

## ¿Cómo se probaron estos cambios?

1. Se verificó que la librería `@testing-library/jest-dom` no se importa más en los archivos de pruebas

## Checklist

• [x] Los cambios han sido probados en el entorno local.  
• [x] La librería `@testing-library/jest-dom` ya no está siendo utilizada en el código de pruebas.  
• [x] No se detectaron regresiones en otras funcionalidades relacionadas con las pruebas.

## Información adicional

La eliminación de `@testing-library/jest-dom` está basada en la recomendación de utilizar las definiciones de tipos incluidas de manera nativa, lo que reduce dependencias innecesarias y mejora la mantenibilidad del proyecto.
