### PR TITLE
ci: se agrego regla para evitar cierre de etiquetas innecesarias en c…

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -45,6 +45,10 @@ export default [
       "react/no-unescaped-entities": 0,
       "react/prop-types": "off",
       "react-hooks/exhaustive-deps": "off",
+      'react/self-closing-comp': ['error', {
+        component: true,
+        html: true
+      }],
     },
     settings: {
       react: {

--- a/src/rules.js
+++ b/src/rules.js
@@ -40,6 +40,12 @@ export const rulesJS = {
   ],
   'no-useless-catch': 'error',
 
+  // React
+  'react/self-closing-comp': ['error', {
+    component: true,
+    html: true
+  }],
+
   // stylistic
   '@stylistic/js/indent': ['error', 2],
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -40,12 +40,6 @@ export const rulesJS = {
   ],
   'no-useless-catch': 'error',
 
-  // React
-  'react/self-closing-comp': ['error', {
-    component: true,
-    html: true
-  }],
-
   // stylistic
   '@stylistic/js/indent': ['error', 2],
 


### PR DESCRIPTION
## Descripción

Este pull request agrega la regla `react/self-closing-comp` a la configuración de ESLint. Esta regla asegura que los componentes sin hijos (tanto HTML como personalizados) se escriban como etiquetas autocerradas, mejorando la legibilidad y consistencia del código.

## Tipo de cambio

• [x] Nueva funcionalidad  
• [ ] Corrección de errores  
• [ ] Mejoras en el rendimiento  
• [ ] Refactorización  
• [ ] Otros (especificar):  

## ¿Cómo se probaron estos cambios?

1. Se creó un proyecto de prueba con React y se conectó mediante `npm link` a este repositorio.
2. Se escribieron componentes con y sin hijos para verificar que la regla marca como error el uso de etiquetas abiertas y cerradas en componentes sin contenido.
3. Se utilizó el flag `--fix` de la forma `npx eslint . --fix` para confirmar que la regla es autocorregible.

## Checklist

• [x] Los cambios han sido probados en el entorno local.  
• [x] Los campos en ambos formularios funcionan correctamente y sin errores.  
• [x] No se detectaron regresiones en otras funcionalidades relacionadas.  

## Información adicional

La regla se agregó con la siguiente configuración:

```js
'react/self-closing-comp': ['error', {
  component: true,
  html: true
}]
