### PR TITLE
Fix Tailwind error and remove unused plugin

### DIFF
--- a/lib/rules/react-tailwind.ts
+++ b/lib/rules/react-tailwind.ts
@@ -1,4 +1,3 @@
-import tailwindcss from "eslint-plugin-tailwindcss";
 import base from "#rules/react.js";
 import { defineConfig } from "eslint/config";
 
@@ -11,7 +10,6 @@ export default defineConfig([
     name: "react:tailwindcss",
     plugins: {
       ...react.plugins,
-      tailwindcss,
     },
     rules: {
       ...react.rules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "eslint-plugin-react-x": "^5.9.2",
-        "eslint-plugin-tailwindcss": "^4.0.3",
         "globals": "^17.6.0",
         "typescript-eslint": "^8.60.1"
       },
@@ -26,7 +25,6 @@
         "@eslint/config-inspector": "^3.0.4",
         "@eslint/js": "^10.0.1",
         "@html-eslint/eslint-plugin": "^0.61.0",
-        "@types/eslint-plugin-tailwindcss": "^3.17.0",
         "@types/node": "^25.9.3",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.5.0",
@@ -34,6 +32,9 @@
         "tsc-alias": "^1.8.17",
         "typescript": "^5.9.3",
         "vitest": "^4.1.8"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2409,27 +2410,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-plugin-tailwindcss": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.17.0.tgz",
-      "integrity": "sha512-ucQGf2YIdTcndYcxRU3UdZgmhUHsOlbIF4BaRtl0op+7k2JmqM2i3aXZ6XIcfZgVq1ZKov7VM5c/BR81ukmkyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*"
-      }
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -3152,12 +3132,6 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "license": "MIT"
     },
-    "node_modules/confbox": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3189,18 +3163,6 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/debug": {
@@ -3280,19 +3242,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
       "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g==",
       "license": "ISC"
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/es-html-parser": {
       "version": "0.3.1",
@@ -3831,30 +3780,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/eslint-plugin-tailwindcss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-4.0.3.tgz",
-      "integrity": "sha512-JSirGfeufS4m6PDV+pflwOPqU3CG3y39xRt5JhRjPrbRagjFbbTcyEjfiClU6aWTQ18HFhMItiBTUWqbjrGoOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.37.0",
-        "postcss": "^8.4.4",
-        "postcss-nested": "^7.0.2",
-        "synckit": "^0.11.11",
-        "tailwind-api-utils": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "tailwindcss": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -3963,12 +3888,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/exsolve": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4194,12 +4113,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
     "node_modules/h3": {
       "version": "2.0.1-rc.22",
       "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
@@ -4395,6 +4308,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -4740,23 +4654,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/local-pkg": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
-      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "mlly": "^1.7.4",
-        "pkg-types": "^2.3.0",
-        "quansync": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4874,35 +4771,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
-    "node_modules/mlly/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
-    },
-    "node_modules/mlly/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4937,6 +4805,7 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5171,6 +5040,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5192,17 +5062,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.2.4",
-        "exsolve": "^1.0.8",
-        "pathe": "^2.0.3"
-      }
-    },
     "node_modules/plimit-lit": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
@@ -5220,6 +5079,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5242,44 +5102,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-7.0.2.tgz",
-      "integrity": "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -5327,22 +5149,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/quansync": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/queue-lit": {
       "version": "1.5.2",
@@ -5658,43 +5464,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tailwind-api-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.3.tgz",
-      "integrity": "sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "enhanced-resolve": "^5.18.1",
-        "jiti": "^2.4.2",
-        "local-pkg": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/hyoban"
-      },
-      "peerDependencies": {
-        "tailwindcss": "^3.3.0 || ^4.0.0 || ^4.0.0-beta"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5892,12 +5661,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -5971,12 +5734,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/valibot": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "eslint-plugin-react-x": "^5.9.2",
-    "eslint-plugin-tailwindcss": "^4.0.3",
     "globals": "^17.6.0",
     "typescript-eslint": "^8.60.1"
   },
@@ -49,7 +48,6 @@
     "@eslint/config-inspector": "^3.0.4",
     "@eslint/js": "^10.0.1",
     "@html-eslint/eslint-plugin": "^0.61.0",
-    "@types/eslint-plugin-tailwindcss": "^3.17.0",
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.5.0",


### PR DESCRIPTION
This pull request removes the integration of the Tailwind CSS ESLint plugin from the project. The main changes involve cleaning up both the code and the dependencies to eliminate references to Tailwind CSS linting.

Plugin removal:

* Removed the import and usage of the `eslint-plugin-tailwindcss` plugin from the `react-tailwind` ESLint configuration (`lib/rules/react-tailwind.ts`). [[1]](diffhunk://#diff-e9b2b6bbd0cb0db270c3bb38ecdbafdae4f4fcb9e5051520d7a22a5fc2ab5413L1) [[2]](diffhunk://#diff-e9b2b6bbd0cb0db270c3bb38ecdbafdae4f4fcb9e5051520d7a22a5fc2ab5413L14)

Dependency cleanup:

* Removed `eslint-plugin-tailwindcss` and its type definitions from `package.json` dependencies and devDependencies.