### PR TITLE
Fix production dependencies location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "@eslint/js": "^10.0.1",
+        "@html-eslint/eslint-plugin": "^0.62.0",
         "@html-eslint/parser": "^0.61.0",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
         "eslint-config-prettier": "^10.1.8",
@@ -23,8 +25,6 @@
       },
       "devDependencies": {
         "@eslint/config-inspector": "^3.0.4",
-        "@eslint/js": "^10.0.1",
-        "@html-eslint/eslint-plugin": "^0.61.0",
         "@types/node": "^25.9.3",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.5.0",
@@ -1412,7 +1412,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1452,32 +1451,41 @@
       }
     },
     "node_modules/@html-eslint/core": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.61.0.tgz",
-      "integrity": "sha512-/dcMywhcO7+CvyV5oUGUkh4641ZyeJyncQas+Ulq7z9fXorTstMrApIzIUdV9TNgkwZZ97Rd8/8XbXkxgoJo6A==",
-      "dev": true,
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.62.0.tgz",
+      "integrity": "sha512-TEWjEE5PcenvXnk27cnQdasR71RDvhlqj6TIu3QHLdpfPo9K11Vx5jWYwM44PS7EaU5+5si2296z72xO1EpLkw==",
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/types": "^0.61.0",
+        "@html-eslint/types": "^0.62.0",
         "html-standard": "^0.0.13"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@html-eslint/core/node_modules/@html-eslint/types": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.62.0.tgz",
+      "integrity": "sha512-lG/Pp0m7OTWmB3PBdAtZNwp35dwjhXVY0jwSqP/47sNPRzVmAOVgxWq2tBQYyH6wJYp3aFZiv1wivd9lUAQZvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-tree": "^2.3.11",
+        "@types/estree": "^1.0.6",
+        "es-html-parser": "0.3.1"
+      }
+    },
     "node_modules/@html-eslint/eslint-plugin": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.61.0.tgz",
-      "integrity": "sha512-iIuyw42ssr3hoBs0dn+ivD4ZPyrMgq1v4Hqx8N3qVEyTcli/XYQ5C20CWPE8msYLU/TmBnvkl0VgzymiIsrRcw==",
-      "dev": true,
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.62.0.tgz",
+      "integrity": "sha512-vtn9fqkI00Q4le7ik7hXopf5VwVJWKQ9Vnle1Jmolvmkb9CKq83DMSWFLCqtlDRkZSi6JKyNIddj6r5Odd+n1w==",
       "license": "MIT",
       "dependencies": {
         "@eslint/plugin-kit": "^0.4.1",
-        "@html-eslint/core": "^0.61.0",
-        "@html-eslint/parser": "^0.61.0",
-        "@html-eslint/template-parser": "^0.61.0",
-        "@html-eslint/template-syntax-parser": "^0.61.0",
-        "@html-eslint/types": "^0.61.0",
+        "@html-eslint/core": "^0.62.0",
+        "@html-eslint/parser": "^0.62.0",
+        "@html-eslint/template-parser": "^0.62.0",
+        "@html-eslint/template-syntax-parser": "^0.62.0",
+        "@html-eslint/types": "^0.62.0",
         "@rviscomi/capo.js": "^2.1.0",
         "html-standard": "^0.0.13"
       },
@@ -1492,7 +1500,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1505,7 +1512,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0",
@@ -1513,6 +1519,38 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@html-eslint/eslint-plugin/node_modules/@html-eslint/parser": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.62.0.tgz",
+      "integrity": "sha512-kb3uR4AX0hex211zAiiNeCZQVVKm0KbSTjWUKaLGPB9DtoL4y0A4ZJXa9DF2GOIFWDt42xJUUvffB2/MEj3ReA==",
+      "license": "MIT",
+      "dependencies": {
+        "@html-eslint/template-syntax-parser": "^0.62.0",
+        "@html-eslint/types": "^0.62.0",
+        "css-tree": "^3.1.0",
+        "es-html-parser": "0.3.1"
+      }
+    },
+    "node_modules/@html-eslint/eslint-plugin/node_modules/@html-eslint/template-syntax-parser": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.62.0.tgz",
+      "integrity": "sha512-XPYul7JI6ld/a3vKOHmIWvCuNpOBc5YIiei5hHJQcCwLeIUyq3yGNUYyJSVF4k4QXe5ksyPfy0MRtOgA1tZ7Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@html-eslint/types": "^0.62.0"
+      }
+    },
+    "node_modules/@html-eslint/eslint-plugin/node_modules/@html-eslint/types": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.62.0.tgz",
+      "integrity": "sha512-lG/Pp0m7OTWmB3PBdAtZNwp35dwjhXVY0jwSqP/47sNPRzVmAOVgxWq2tBQYyH6wJYp3aFZiv1wivd9lUAQZvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-tree": "^2.3.11",
+        "@types/estree": "^1.0.6",
+        "es-html-parser": "0.3.1"
       }
     },
     "node_modules/@html-eslint/parser": {
@@ -1528,13 +1566,23 @@
       }
     },
     "node_modules/@html-eslint/template-parser": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.61.0.tgz",
-      "integrity": "sha512-mPN9UsW02m+WtDQb48FLzTCVDCBuXboRzDO37yPipp6ai98IDJBslrFjmHHh8dwBIs9QlQXWpTdlRiV3NvTwtA==",
-      "dev": true,
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.62.0.tgz",
+      "integrity": "sha512-sI3Fiy4nsXGsp7k61UA3P/QooqUALE8oz2KuFzXb8Jb3krxlVQWwFXE8Ipr62r53jZyMz8XVsvaMUiP0nwrJsw==",
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/types": "^0.61.0",
+        "@html-eslint/types": "^0.62.0",
+        "es-html-parser": "0.3.1"
+      }
+    },
+    "node_modules/@html-eslint/template-parser/node_modules/@html-eslint/types": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.62.0.tgz",
+      "integrity": "sha512-lG/Pp0m7OTWmB3PBdAtZNwp35dwjhXVY0jwSqP/47sNPRzVmAOVgxWq2tBQYyH6wJYp3aFZiv1wivd9lUAQZvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-tree": "^2.3.11",
+        "@types/estree": "^1.0.6",
         "es-html-parser": "0.3.1"
       }
     },
@@ -2353,7 +2401,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@rviscomi/capo.js/-/capo.js-2.1.0.tgz",
       "integrity": "sha512-y6J+KJqsrY8AcDswLKkvd8KdpFindjS4Q9rSuK8CIpsQOepEjgRaMR4S8OtuLOQoVYLCROT3ffMQqRWrUMQdQA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@sindresorhus/base62": {
@@ -2815,7 +2862,6 @@
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
       "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
@@ -4190,7 +4236,6 @@
       "version": "0.0.13",
       "resolved": "https://registry.npmjs.org/html-standard/-/html-standard-0.0.13.tgz",
       "integrity": "sha512-6oNfW3c1t44O7jVXu0tp4E5MbHifWlXrHlZBPt6y7vFdgLOUUh8hyzoRhfUgozlBUK6oLLYhqP1uIqbZ8ggcBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-css-languageservice": "^6.3.9",
@@ -5948,7 +5993,6 @@
       "version": "6.3.10",
       "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
       "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -5961,21 +6005,18 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/webpack-virtual-modules": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "author": "Habid Manzur <hmanzur>",
   "license": "MIT",
   "dependencies": {
+    "@eslint/js": "^10.0.1",
+    "@html-eslint/eslint-plugin": "^0.62.0",
     "@html-eslint/parser": "^0.61.0",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "eslint-config-prettier": "^10.1.8",
@@ -46,8 +48,6 @@
   },
   "devDependencies": {
     "@eslint/config-inspector": "^3.0.4",
-    "@eslint/js": "^10.0.1",
-    "@html-eslint/eslint-plugin": "^0.61.0",
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.5.0",


### PR DESCRIPTION
This pull request updates the project's linting dependencies by moving some ESLint-related packages from `devDependencies` to `dependencies`, and also updates the version of `@html-eslint/eslint-plugin`. These changes help ensure that the correct versions of linting tools are available in the appropriate environment.

Dependency management:

* Moved `@eslint/js` and `@html-eslint/eslint-plugin` from `devDependencies` to `dependencies` in `package.json`, and updated `@html-eslint/eslint-plugin` from version `^0.61.0` to `^0.62.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R35-R36) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-L50)